### PR TITLE
ci: switch audit step to direct cargo-audit call

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,16 @@ jobs:
   audit:
     name: cargo audit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
-      - uses: rustsec/audit-check@v2.0.0
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          shared-key: cargo-audit
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+      - name: cargo audit
+        run: cargo audit


### PR DESCRIPTION
## Why
The audit job was failing on master push for two reasons:

1. \`rustsec/audit-check@v2.0.0\` tries to create a check run via the GitHub API and our job didn't grant \`checks: write\` — fails with \"Resource not accessible by integration\".
2. The action's \`--deny warnings\` behavior treats informational notices (unmaintained, yanked) as build failures. We currently get four of those transitively, none of them actionable here:
   - \`async-std\`, \`instant\` — via \`httpmock\` 0.6 (dev-dep)
   - \`rustls-pemfile\` — via \`reqwest\` 0.12
   - \`futures-util 0.3.28\` — via \`hyper-util\`

## What
- Drop \`rustsec/audit-check\`; run \`cargo audit\` directly.
- \`cargo audit\` exits non-zero only on real vulnerabilities, prints informational warnings without failing, and needs no GitHub API permissions.
- Install via \`taiki-e/install-action\` (prebuilt binary, ~5s) instead of compiling cargo-audit from source (~3 min).
- Add explicit \`permissions: { contents: read }\` to the audit job for least-privilege.

## Test plan
- [x] \`cargo audit\` locally exits 0 with the master lockfile (\"4 allowed warnings found\", no vulnerabilities)
- [ ] CI on this PR is green